### PR TITLE
Added support for predefined variables

### DIFF
--- a/JSLint.sublime-build
+++ b/JSLint.sublime-build
@@ -2,6 +2,9 @@
 	"cmd": [
 	  "node", 
 	  "${packages}/JSLint/linter.js",
+
+	  // Examples using predef flag
+	  "--predef", "['angular', 'document', '\\$', '_', 'JQuery', 'FB']",
 	  // tolerate missing 'use strict' pragma
 	  "--sloppy",
 	  // suggest an indent level of two spaces

--- a/linter.js
+++ b/linter.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var args = process.argv;
 args.splice(0, 2);
 
-var argsWithVals  = ["indent", "maxerr", "maxlen"];
+var argsWithVals  = ["indent", "maxerr", "maxlen", "predef"];
 var valueExpected = null;
 var srcFile = null;
 var options = {};
@@ -21,6 +21,9 @@ args.forEach(function (val, index, array) {
     }
   } else {
     if (valueExpected) {
+      if (val.indexOf('[') === 0) {
+        val = eval(val);
+      }
       options[valueExpected] = val;
       valueExpected = null;
     } else if (index === args.length - 1) {


### PR DESCRIPTION
Hi there Darren,

I installed your jslint plugin yesterday, which I found pretty useful, but wasn't able to find the way to pass some global variables to JSLint.

Inspecting the code, I saw that JSLint accepted predef variables in the form of either an Array or and object (line 6068), so I just made a pretty straigthforward change in linter.js to accept a "predef" argument followed by a string containing a javascript syntax compliant array of strings.

Do as you wish with this commit.

Regards.
